### PR TITLE
Typo pluginS instead of plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Add to your OpenCode config (`opencode.json` or `.opencode/config.json`):
 
 ```json
 {
-  "plugins": ["openrtk"]
+  "plugin": ["openrtk"]
 }
 ```
 


### PR DESCRIPTION
As per the doc it should be singular: https://opencode.ai/docs/plugins/#from-npm